### PR TITLE
fix: Security hardening for input validation

### DIFF
--- a/scripts/finalize-flatten.sh
+++ b/scripts/finalize-flatten.sh
@@ -15,5 +15,5 @@ if [[ "$FORMAT" == "MKA" ]] ;then
 fi
 
 if [[ "$JMR_FINALIZE_WEBHOOK" != "" ]] ;then
-  curl -s -o /dev/null "$JMR_FINALIZE_WEBHOOK?meetingId=$MEETING_ID"
+  curl -s -o /dev/null --get --data-urlencode "meetingId=$MEETING_ID" "$JMR_FINALIZE_WEBHOOK"
 fi

--- a/scripts/flatten-mka.sh
+++ b/scripts/flatten-mka.sh
@@ -12,7 +12,7 @@ if [ -z "$input_mka_file" -o -z "$output_file" ] ;then
 fi
 
 # Step 1: Get the JSON output from ffprobe
-ffprobe_output=$(ffprobe -i $1 -show_entries stream=index,start_time -v quiet -select_streams a -print_format json -analyzeduration 9223372036854775807)
+ffprobe_output=$(ffprobe -i "$1" -show_entries stream=index,start_time -v quiet -select_streams a -print_format json -analyzeduration 9223372036854775807)
 
 # Step 2: Parse the JSON to extract audio streams and their start times using jq
 streams=$(echo "$ffprobe_output" | jq -r '.streams[] | "\(.index) \(.start_time)"')

--- a/src/main/kotlin/org/jitsi/recorder/Main.kt
+++ b/src/main/kotlin/org/jitsi/recorder/Main.kt
@@ -46,7 +46,7 @@ fun Application.module() {
     install(WebSockets) {
         pingPeriod = 15.seconds
         timeout = 15.seconds
-        maxFrameSize = Long.MAX_VALUE
+        maxFrameSize = 1024 * 1024 // 1 MB
         masking = false
     }
     routing {


### PR DESCRIPTION
- Cap WebSocket maxFrameSize at 1 MB to prevent memory exhaustion DoS
- URL-encode meetingId in webhook curl call to prevent parameter injection
- Quote $1 in ffprobe invocation to prevent word splitting
